### PR TITLE
docs: add osx support and clearer docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,7 @@ Prerequisites:
 To build the packages, run:
 
 ```sh
-sh build.sh
+./build.sh
 ```
 
 This will build the C# code and run tests.
@@ -18,14 +18,13 @@ When the [google-cloudevents repo](https://github.com/googleapis/google-cloudeve
 the C# classes need to be regenerated:
 
 ```sh
-sh generate-protos.sh
+./generate-protos.sh
 ```
 
-This will regenerate teh proto-based classes in [src/Google.Events.Protobuf/](src/Google.Events.Protobuf).
+This will regenerate the proto-based classes in [src/Google.Events.Protobuf/](src/Google.Events.Protobuf).
 
 ---
 
 If event data types or properties have been added,
 the tests for other serialization frameworks will fail.
-
 The tests should currently be fixed by manually adding the corresponding types and properties.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,25 +1,31 @@
 # Building
 
-Build prerequisites: .NET Core SDK 3.1
+Prerequisites:
 
-To build the packages, simply run [`build.sh`](build.sh) from the root
-directory. This will build the C# code and run tests.
+- `.NET Core SDK 3.1`
+
+To build the packages, run:
+
+```sh
+sh build.sh
+```
+
+This will build the C# code and run tests.
 
 ## Regenerating event data classes
 
-When the [google-cloudevents
-repo](https://github.com/googleapis/google-cloudevents) is updated,
-the C# classes need to be regenerated. Run
-[`generate-protos.sh`](generate-protos.sh) from the root directory to
-do this; the proto-based classes in [src/Google.Events.Protobuf](src/Google.Events.Protobuf) will be
-regenerated.
+When the [google-cloudevents repo](https://github.com/googleapis/google-cloudevents) is updated,
+the C# classes need to be regenerated:
 
-If event data types or properties have been added, the tests for
-other serialization frameworks will fail; the tests should currently
-be fixed by manually adding the corresponding types and properties.
+```sh
+sh generate-protos.sh
+```
 
-Note: this is currently only supported on Linux and Windows; if you
-are developing on another platform, please edit `generate-protos.sh`
-appropriately, and create a pull request with the changes. (It's just
-a matter of knowing which zip file to download for `protoc`, and
-where the `protoc` binary is within it.)
+This will regenerate teh proto-based classes in [src/Google.Events.Protobuf/](src/Google.Events.Protobuf).
+
+---
+
+If event data types or properties have been added,
+the tests for other serialization frameworks will fail.
+
+The tests should currently be fixed by manually adding the corresponding types and properties.

--- a/generate-protos.sh
+++ b/generate-protos.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to generate the Protobuf classes from google/google-cloudevents
+# Script to generate the Protobuf classes from googleapis/google-cloudevents
 set -e
 
 echo "~ START"
@@ -31,7 +31,7 @@ echo "- Cloning github.com/googleapis/google-cloudevents into tmp"
 # it a submodule. We clone quietly, and only with a depth of 1
 # as we don't need history.
 rm -rf tmp
-mkdir -p tmp
+mkdir tmp
 git clone https://github.com/googleapis/google-cloudevents tmp/google-cloudevents -q --depth 1
 
 # We download a specific version rather than using package managers
@@ -42,7 +42,7 @@ cd tmp
 curl -sSL \
   https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-$PROTOBUF_PLATFORM.zip \
   --output protobuf.zip
-(mkdir -p protobuf && cd protobuf && unzip -q ../protobuf.zip)
+(mkdir protobuf && cd protobuf && unzip -q ../protobuf.zip)
 cd ..
 chmod +x $PROTOC
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-dotnet/issues/7.

Simplifies and formats the instructions.

```
~ START
- Determining OS type
- Cloning github.com/googleapis/google-cloudevents into tmp
- Downloading protobuf tools
- Generating src/
- Removing tmp/
~ DONE ✓
```