### PR TITLE
chore: add CODEOWNERS and repo settings config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+*     @googleapis/cloudevents-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloudevents-admins
+*     @googleapis/yoshi-dotnet

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,13 @@
+rebaseMergeAllowed: true
+squashMergeAllowed: true
+mergeCommitAllowed: false
+branchProtectionRules:
+- pattern: master
+  requiredStatusCheckContexts:
+    - 'cla/google'
+  requiredApprovingReviewCount: 1
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+permissionRules:
+  - team: cloudevents-admins
+    permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -4,6 +4,7 @@ mergeCommitAllowed: false
 branchProtectionRules:
 - pattern: master
   requiredStatusCheckContexts:
+    - 'build'
     - 'cla/google'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,5 +10,7 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
 permissionRules:
+  - team: yoshi-dotnet
+    permission: push
   - team: cloudevents-admins
     permission: admin


### PR DESCRIPTION
In pursuit of keeping standards with go/cloud-dpe-oss-standards, we filed https://github.com/googleapis/google-cloudevents-dotnet/issues/27.  It looks like that got resolved, but branch protection isn't set up on the repo.  This file will ensure sync-repo-settings bot configures these things on a nightly basis.  