### PR TITLE
Fix autorelease build to use tags

### DIFF
--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -42,15 +42,21 @@ source /tmp/publisher-script
 COMMITTISH=$COMMITTISH_OVERRIDE
 if [[ $COMMITTISH_OVERRIDE = "" ]]
 then
-  COMMITTISH=$(git rev-parse HEAD)
-else
-  COMMITTISH=$COMMITTISH_OVERRIDE
+  COMMITTISH=HEAD
 fi
 
-echo "Building with commit $COMMITTISH"
+TAG=$(git tag --points-at $COMMITTISH | head -n 1)
+
+if [[ $TAG = "" ]]
+then
+  echo "Committish $COMMITTISH does not point at a tag. Aborting."
+  exit 1
+fi
+
+echo "Building with tag $TAG"
 
 # Build the release and run the tests.
-./build-release.sh $COMMITTISH
+./build-release.sh $TAG
 
 if [[ $SKIP_NUGET_PUSH = "" ]]
 then

--- a/build-release.sh
+++ b/build-release.sh
@@ -12,7 +12,7 @@ rm -rf tmp
 mkdir tmp
 
 git clone https://github.com/googleapis/google-cloudevents-dotnet.git \
-  --depth 1 -b $1 tmp/release
+  --depth 1 -b $1 --recursive tmp/release
   
 cd tmp/release
 ./build.sh


### PR DESCRIPTION
This validates that the committish we build genuinely points at a
tag, and passes the tag to build-release (which expects one).

Also clone recursively in build-release. (Currently no submodules
here, but it's easy to miss when one is introduced.)