### PR TITLE
Release Google.Events packages version 1.0.0-beta01

### DIFF
--- a/src/ProductionProperties.xml
+++ b/src/ProductionProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-alpha06</Version>
+    <Version>1.0.0-beta01</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Changes since 1.0.0-alpha06:

No API surface changes. This release is primarily to promote to beta.

Packages in this release:
- Release Google.Events version 1.0.0-beta01
- Release Google.Events.Protobuf version 1.0.0-beta01