### PR TITLE
Release Google.Events packages version 1.0.0-beta03

### DIFF
--- a/src/Google.Events.Protobuf/Cloud/Audit/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Audit/V1/Data.g.cs
@@ -173,10 +173,7 @@ namespace Google.Events.Protobuf.Cloud.Audit.V1 {
 
   #region Messages
   /// <summary>
-  /// Generic log entry, used as a wrapper for Cloud Audit Logs in events.
-  /// This is copied from
-  /// https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto
-  /// and adapted appropriately.
+  /// The data within all Cloud Audit Logs log entry events.
   /// </summary>
   public sealed partial class LogEntryData : pb::IMessage<LogEntryData>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE

--- a/src/Google.Events.Protobuf/Cloud/Audit/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Audit/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Audit/V1/LogEntryData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Audit/V1/LogEntryData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/BuildEventData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/BuildEventData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/CloudBuild/V1/Data.g.cs
@@ -175,10 +175,7 @@ namespace Google.Events.Protobuf.Cloud.CloudBuild.V1 {
   }
   #region Messages
   /// <summary>
-  /// Build event data
-  /// Common build format for Google Cloud Platform API operations.
-  /// Copied from
-  /// https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto.
+  /// Build event data for Google Cloud Platform API operations.
   /// </summary>
   public sealed partial class BuildEventData : pb::IMessage<BuildEventData>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE

--- a/src/Google.Events.Protobuf/Cloud/Firestore/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Firestore/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Firestore/V1/DocumentEventData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Firestore/V1/DocumentEventData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
@@ -60,7 +60,7 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
   }
   #region Messages
   /// <summary>
-  /// The data received in an event when a message is published to a topic.
+  /// The event data when a message is published to a topic.
   /// </summary>
   public sealed partial class MessagePublishedData : pb::IMessage<MessagePublishedData>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE

--- a/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/PubSub/V1/Data.g.cs
@@ -39,20 +39,22 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "Cihnb29nbGUvZXZlbnRzL2Nsb3VkL3B1YnN1Yi92MS9kYXRhLnByb3RvEh1n",
-            "b29nbGUuZXZlbnRzLmNsb3VkLnB1YnN1Yi52MSJrChRNZXNzYWdlUHVibGlz",
-            "aGVkRGF0YRI9CgdtZXNzYWdlGAEgASgLMiwuZ29vZ2xlLmV2ZW50cy5jbG91",
-            "ZC5wdWJzdWIudjEuUHVic3ViTWVzc2FnZRIUCgxzdWJzY3JpcHRpb24YAiAB",
-            "KAkitgEKDVB1YnN1Yk1lc3NhZ2USDAoEZGF0YRgBIAEoDBJQCgphdHRyaWJ1",
-            "dGVzGAIgAygLMjwuZ29vZ2xlLmV2ZW50cy5jbG91ZC5wdWJzdWIudjEuUHVi",
-            "c3ViTWVzc2FnZS5BdHRyaWJ1dGVzRW50cnkSEgoKbWVzc2FnZV9pZBgDIAEo",
-            "CRoxCg9BdHRyaWJ1dGVzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIg",
-            "ASgJOgI4AUIpqgImR29vZ2xlLkV2ZW50cy5Qcm90b2J1Zi5DbG91ZC5QdWJT",
-            "dWIuVjFiBnByb3RvMw=="));
+            "b29nbGUuZXZlbnRzLmNsb3VkLnB1YnN1Yi52MRofZ29vZ2xlL3Byb3RvYnVm",
+            "L3RpbWVzdGFtcC5wcm90byJrChRNZXNzYWdlUHVibGlzaGVkRGF0YRI9Cgdt",
+            "ZXNzYWdlGAEgASgLMiwuZ29vZ2xlLmV2ZW50cy5jbG91ZC5wdWJzdWIudjEu",
+            "UHVic3ViTWVzc2FnZRIUCgxzdWJzY3JpcHRpb24YAiABKAki6AEKDVB1YnN1",
+            "Yk1lc3NhZ2USDAoEZGF0YRgBIAEoDBJQCgphdHRyaWJ1dGVzGAIgAygLMjwu",
+            "Z29vZ2xlLmV2ZW50cy5jbG91ZC5wdWJzdWIudjEuUHVic3ViTWVzc2FnZS5B",
+            "dHRyaWJ1dGVzRW50cnkSEgoKbWVzc2FnZV9pZBgDIAEoCRIwCgxwdWJsaXNo",
+            "X3RpbWUYBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wGjEKD0F0",
+            "dHJpYnV0ZXNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgB",
+            "QimqAiZHb29nbGUuRXZlbnRzLlByb3RvYnVmLkNsb3VkLlB1YlN1Yi5WMWIG",
+            "cHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { },
+          new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Cloud.PubSub.V1.MessagePublishedData), global::Google.Events.Protobuf.Cloud.PubSub.V1.MessagePublishedData.Parser, new[]{ "Message", "Subscription" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Cloud.PubSub.V1.PubsubMessage), global::Google.Events.Protobuf.Cloud.PubSub.V1.PubsubMessage.Parser, new[]{ "Data", "Attributes", "MessageId" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, })
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Cloud.PubSub.V1.PubsubMessage), global::Google.Events.Protobuf.Cloud.PubSub.V1.PubsubMessage.Parser, new[]{ "Data", "Attributes", "MessageId", "PublishTime" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, })
           }));
     }
     #endregion
@@ -322,6 +324,7 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       data_ = other.data_;
       attributes_ = other.attributes_.Clone();
       messageId_ = other.messageId_;
+      publishTime_ = other.publishTime_ != null ? other.publishTime_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -372,6 +375,21 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       }
     }
 
+    /// <summary>Field number for the "publish_time" field.</summary>
+    public const int PublishTimeFieldNumber = 4;
+    private global::Google.Protobuf.WellKnownTypes.Timestamp publishTime_;
+    /// <summary>
+    /// The time at which the message was published, populated by the server when
+    /// it receives the `Publish` call.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Google.Protobuf.WellKnownTypes.Timestamp PublishTime {
+      get { return publishTime_; }
+      set {
+        publishTime_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as PubsubMessage);
@@ -388,6 +406,7 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       if (Data != other.Data) return false;
       if (!Attributes.Equals(other.Attributes)) return false;
       if (MessageId != other.MessageId) return false;
+      if (!object.Equals(PublishTime, other.PublishTime)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -397,6 +416,7 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       if (Data.Length != 0) hash ^= Data.GetHashCode();
       hash ^= Attributes.GetHashCode();
       if (MessageId.Length != 0) hash ^= MessageId.GetHashCode();
+      if (publishTime_ != null) hash ^= PublishTime.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -422,6 +442,10 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
         output.WriteRawTag(26);
         output.WriteString(MessageId);
       }
+      if (publishTime_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(PublishTime);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -440,6 +464,10 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
         output.WriteRawTag(26);
         output.WriteString(MessageId);
       }
+      if (publishTime_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(PublishTime);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -455,6 +483,9 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       size += attributes_.CalculateSize(_map_attributes_codec);
       if (MessageId.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(MessageId);
+      }
+      if (publishTime_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(PublishTime);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -473,6 +504,12 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
       attributes_.Add(other.attributes_);
       if (other.MessageId.Length != 0) {
         MessageId = other.MessageId;
+      }
+      if (other.publishTime_ != null) {
+        if (publishTime_ == null) {
+          PublishTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+        }
+        PublishTime.MergeFrom(other.PublishTime);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -500,6 +537,13 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
             MessageId = input.ReadString();
             break;
           }
+          case 34: {
+            if (publishTime_ == null) {
+              PublishTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            }
+            input.ReadMessage(PublishTime);
+            break;
+          }
         }
       }
     #endif
@@ -524,6 +568,13 @@ namespace Google.Events.Protobuf.Cloud.PubSub.V1 {
           }
           case 26: {
             MessageId = input.ReadString();
+            break;
+          }
+          case 34: {
+            if (publishTime_ == null) {
+              PublishTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            }
+            input.ReadMessage(PublishTime);
             break;
           }
         }

--- a/src/Google.Events.Protobuf/Cloud/PubSub/V1/MessagePublishedData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/PubSub/V1/MessagePublishedData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Scheduler/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Scheduler/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Scheduler/V1/SchedulerJobData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Scheduler/V1/SchedulerJobData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Storage/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Storage/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Cloud/Storage/V1/StorageObjectData.g.cs
+++ b/src/Google.Events.Protobuf/Cloud/Storage/V1/StorageObjectData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Analytics/V1/AnalyticsLogData.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Analytics/V1/AnalyticsLogData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Analytics/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Analytics/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Auth/V1/AuthEventData.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Auth/V1/AuthEventData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
@@ -48,18 +48,18 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
             "LnYxLlVzZXJNZXRhZGF0YRI/Cg1wcm92aWRlcl9kYXRhGAggAygLMiguZ29v",
             "Z2xlLmV2ZW50cy5maXJlYmFzZS5hdXRoLnYxLlVzZXJJbmZvEhQKDHBob25l",
             "X251bWJlchgJIAEoCRIuCg1jdXN0b21fY2xhaW1zGAogASgLMhcuZ29vZ2xl",
-            "LnByb3RvYnVmLlN0cnVjdCJ1CgxVc2VyTWV0YWRhdGESLgoKY3JlYXRlZF9h",
-            "dBgBIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASNQoRbGFzdF9z",
-            "aWduZWRfaW5fYXQYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1w",
-            "ImQKCFVzZXJJbmZvEgsKA3VpZBgBIAEoCRINCgVlbWFpbBgCIAEoCRIUCgxk",
-            "aXNwbGF5X25hbWUYAyABKAkSEQoJcGhvdG9fVVJMGAQgASgJEhMKC3Byb3Zp",
-            "ZGVyX2lkGAUgASgJQiqqAidHb29nbGUuRXZlbnRzLlByb3RvYnVmLkZpcmVi",
-            "YXNlLkF1dGguVjFiBnByb3RvMw=="));
+            "LnByb3RvYnVmLlN0cnVjdCJ2CgxVc2VyTWV0YWRhdGESLwoLY3JlYXRlX3Rp",
+            "bWUYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjUKEWxhc3Rf",
+            "c2lnbl9pbl90aW1lGAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFt",
+            "cCJkCghVc2VySW5mbxILCgN1aWQYASABKAkSDQoFZW1haWwYAiABKAkSFAoM",
+            "ZGlzcGxheV9uYW1lGAMgASgJEhEKCXBob3RvX1VSTBgEIAEoCRITCgtwcm92",
+            "aWRlcl9pZBgFIAEoCUIqqgInR29vZ2xlLkV2ZW50cy5Qcm90b2J1Zi5GaXJl",
+            "YmFzZS5BdXRoLlYxYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Firebase.Auth.V1.AuthEventData), global::Google.Events.Protobuf.Firebase.Auth.V1.AuthEventData.Parser, new[]{ "Uid", "Email", "EmailVerified", "DisplayName", "PhotoURL", "Disabled", "Metadata", "ProviderData", "PhoneNumber", "CustomClaims" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Firebase.Auth.V1.UserMetadata), global::Google.Events.Protobuf.Firebase.Auth.V1.UserMetadata.Parser, new[]{ "CreatedAt", "LastSignedInAt" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Firebase.Auth.V1.UserMetadata), global::Google.Events.Protobuf.Firebase.Auth.V1.UserMetadata.Parser, new[]{ "CreateTime", "LastSignInTime" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Events.Protobuf.Firebase.Auth.V1.UserInfo), global::Google.Events.Protobuf.Firebase.Auth.V1.UserInfo.Parser, new[]{ "Uid", "Email", "DisplayName", "PhotoURL", "ProviderId" }, null, null, null, null)
           }));
     }
@@ -636,8 +636,8 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public UserMetadata(UserMetadata other) : this() {
-      createdAt_ = other.createdAt_ != null ? other.createdAt_.Clone() : null;
-      lastSignedInAt_ = other.lastSignedInAt_ != null ? other.lastSignedInAt_.Clone() : null;
+      createTime_ = other.createTime_ != null ? other.createTime_.Clone() : null;
+      lastSignInTime_ = other.lastSignInTime_ != null ? other.lastSignInTime_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -646,31 +646,31 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
       return new UserMetadata(this);
     }
 
-    /// <summary>Field number for the "created_at" field.</summary>
-    public const int CreatedAtFieldNumber = 1;
-    private global::Google.Protobuf.WellKnownTypes.Timestamp createdAt_;
+    /// <summary>Field number for the "create_time" field.</summary>
+    public const int CreateTimeFieldNumber = 1;
+    private global::Google.Protobuf.WellKnownTypes.Timestamp createTime_;
     /// <summary>
     /// The date the user was created.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::Google.Protobuf.WellKnownTypes.Timestamp CreatedAt {
-      get { return createdAt_; }
+    public global::Google.Protobuf.WellKnownTypes.Timestamp CreateTime {
+      get { return createTime_; }
       set {
-        createdAt_ = value;
+        createTime_ = value;
       }
     }
 
-    /// <summary>Field number for the "last_signed_in_at" field.</summary>
-    public const int LastSignedInAtFieldNumber = 2;
-    private global::Google.Protobuf.WellKnownTypes.Timestamp lastSignedInAt_;
+    /// <summary>Field number for the "last_sign_in_time" field.</summary>
+    public const int LastSignInTimeFieldNumber = 2;
+    private global::Google.Protobuf.WellKnownTypes.Timestamp lastSignInTime_;
     /// <summary>
     /// The date the user last signed in.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::Google.Protobuf.WellKnownTypes.Timestamp LastSignedInAt {
-      get { return lastSignedInAt_; }
+    public global::Google.Protobuf.WellKnownTypes.Timestamp LastSignInTime {
+      get { return lastSignInTime_; }
       set {
-        lastSignedInAt_ = value;
+        lastSignInTime_ = value;
       }
     }
 
@@ -687,16 +687,16 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
       if (ReferenceEquals(other, this)) {
         return true;
       }
-      if (!object.Equals(CreatedAt, other.CreatedAt)) return false;
-      if (!object.Equals(LastSignedInAt, other.LastSignedInAt)) return false;
+      if (!object.Equals(CreateTime, other.CreateTime)) return false;
+      if (!object.Equals(LastSignInTime, other.LastSignInTime)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (createdAt_ != null) hash ^= CreatedAt.GetHashCode();
-      if (lastSignedInAt_ != null) hash ^= LastSignedInAt.GetHashCode();
+      if (createTime_ != null) hash ^= CreateTime.GetHashCode();
+      if (lastSignInTime_ != null) hash ^= LastSignInTime.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -713,13 +713,13 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (createdAt_ != null) {
+      if (createTime_ != null) {
         output.WriteRawTag(10);
-        output.WriteMessage(CreatedAt);
+        output.WriteMessage(CreateTime);
       }
-      if (lastSignedInAt_ != null) {
+      if (lastSignInTime_ != null) {
         output.WriteRawTag(18);
-        output.WriteMessage(LastSignedInAt);
+        output.WriteMessage(LastSignInTime);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -730,13 +730,13 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (createdAt_ != null) {
+      if (createTime_ != null) {
         output.WriteRawTag(10);
-        output.WriteMessage(CreatedAt);
+        output.WriteMessage(CreateTime);
       }
-      if (lastSignedInAt_ != null) {
+      if (lastSignInTime_ != null) {
         output.WriteRawTag(18);
-        output.WriteMessage(LastSignedInAt);
+        output.WriteMessage(LastSignInTime);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -747,11 +747,11 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (createdAt_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(CreatedAt);
+      if (createTime_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(CreateTime);
       }
-      if (lastSignedInAt_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(LastSignedInAt);
+      if (lastSignInTime_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(LastSignInTime);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -764,17 +764,17 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
       if (other == null) {
         return;
       }
-      if (other.createdAt_ != null) {
-        if (createdAt_ == null) {
-          CreatedAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+      if (other.createTime_ != null) {
+        if (createTime_ == null) {
+          CreateTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
         }
-        CreatedAt.MergeFrom(other.CreatedAt);
+        CreateTime.MergeFrom(other.CreateTime);
       }
-      if (other.lastSignedInAt_ != null) {
-        if (lastSignedInAt_ == null) {
-          LastSignedInAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+      if (other.lastSignInTime_ != null) {
+        if (lastSignInTime_ == null) {
+          LastSignInTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
         }
-        LastSignedInAt.MergeFrom(other.LastSignedInAt);
+        LastSignInTime.MergeFrom(other.LastSignInTime);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -791,17 +791,17 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (createdAt_ == null) {
-              CreatedAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            if (createTime_ == null) {
+              CreateTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
-            input.ReadMessage(CreatedAt);
+            input.ReadMessage(CreateTime);
             break;
           }
           case 18: {
-            if (lastSignedInAt_ == null) {
-              LastSignedInAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            if (lastSignInTime_ == null) {
+              LastSignInTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
-            input.ReadMessage(LastSignedInAt);
+            input.ReadMessage(LastSignInTime);
             break;
           }
         }
@@ -819,17 +819,17 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
           case 10: {
-            if (createdAt_ == null) {
-              CreatedAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            if (createTime_ == null) {
+              CreateTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
-            input.ReadMessage(CreatedAt);
+            input.ReadMessage(CreateTime);
             break;
           }
           case 18: {
-            if (lastSignedInAt_ == null) {
-              LastSignedInAt = new global::Google.Protobuf.WellKnownTypes.Timestamp();
+            if (lastSignInTime_ == null) {
+              LastSignInTime = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
-            input.ReadMessage(LastSignedInAt);
+            input.ReadMessage(LastSignInTime);
             break;
           }
         }

--- a/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
@@ -68,7 +68,7 @@ namespace Google.Events.Protobuf.Firebase.Auth.V1 {
   }
   #region Messages
   /// <summary>
-  /// The data within all Firebase Auth events
+  /// The data within all Firebase Auth events.
   /// </summary>
   public sealed partial class AuthEventData : pb::IMessage<AuthEventData>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE

--- a/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Auth/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Database/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Database/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/Database/V1/ReferenceEventData.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/Database/V1/ReferenceEventData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/RemoteConfig/V1/Data.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/RemoteConfig/V1/Data.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Google.Events.Protobuf/Firebase/RemoteConfig/V1/RemoteConfigEventData.g.cs
+++ b/src/Google.Events.Protobuf/Firebase/RemoteConfig/V1/RemoteConfigEventData.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC
+// Copyright 2021, Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ProductionProperties.xml
+++ b/src/ProductionProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Changes since 1.0.0-beta02 :

- Added PublishTime to PubsubMessage
- Renamed two Firebase auth fields
  (requires Functions Framework compatibility changes)

Packages in this release:

- Release Google.Events version 1.0.0-beta03
- Release Google.Events.Protobuf version 1.0.0-beta03