### PR TITLE
Release Google.Events.Protobuf version 1.0.0-beta05

### DIFF
--- a/src/Google.Events.Protobuf.Tests/ProtobufJsonCloudEventFormatterTest.cs
+++ b/src/Google.Events.Protobuf.Tests/ProtobufJsonCloudEventFormatterTest.cs
@@ -106,7 +106,7 @@ namespace Google.Events.Protobuf.Tests
             var expectedBytes = TestResourceHelper.LoadBytes("structured-mode-body.json");
 
             var converter = new ProtobufJsonCloudEventFormatter<StorageObjectData>();
-            var actualBytes = converter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+            var actualBytes = converter.EncodeStructuredModeMessage(cloudEvent, out var contentType).ToArray();
             Assert.Equal("application/cloudevents+json", contentType.MediaType);
 
             AssertJsonBytesEqual(expectedBytes, actualBytes);
@@ -119,7 +119,7 @@ namespace Google.Events.Protobuf.Tests
             cloudEvent.Data = null;
 
             var converter = new ProtobufJsonCloudEventFormatter<StorageObjectData>();
-            var bytes = converter.EncodeStructuredModeMessage(cloudEvent, out var contentType);
+            var bytes = converter.EncodeStructuredModeMessage(cloudEvent, out var contentType).ToArray();
             Assert.Equal("application/cloudevents+json", contentType.MediaType);
 
             var obj = JObject.Parse(Encoding.UTF8.GetString(bytes));
@@ -133,7 +133,7 @@ namespace Google.Events.Protobuf.Tests
             var expectedBytes = TestResourceHelper.LoadBytes("binary-mode-body.json");
 
             var converter = new ProtobufJsonCloudEventFormatter<StorageObjectData>();
-            var actualBytes = converter.EncodeBinaryModeEventData(cloudEvent);
+            var actualBytes = converter.EncodeBinaryModeEventData(cloudEvent).ToArray();
 
             AssertJsonBytesEqual(expectedBytes, actualBytes);
         }
@@ -145,7 +145,7 @@ namespace Google.Events.Protobuf.Tests
             cloudEvent.Data = null;
 
             var converter = new ProtobufJsonCloudEventFormatter<StorageObjectData>();
-            Assert.Empty(converter.EncodeBinaryModeEventData(cloudEvent));
+            Assert.Empty(converter.EncodeBinaryModeEventData(cloudEvent).ToArray());
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Google.Events.Protobuf.Tests
             var expectedBytes = TestResourceHelper.LoadBytes("batch-body.json");
 
             var converter = new ProtobufJsonCloudEventFormatter<StorageObjectData>();
-            var actualBytes = converter.EncodeBatchModeMessage(batch, out var contentType);
+            var actualBytes = converter.EncodeBatchModeMessage(batch, out var contentType).ToArray();
             Assert.Equal("application/cloudevents-batch+json", contentType.MediaType);
 
             AssertJsonBytesEqual(expectedBytes, actualBytes);

--- a/src/Google.Events.Protobuf/Google.Events.Protobuf.csproj
+++ b/src/Google.Events.Protobuf/Google.Events.Protobuf.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="2.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
-    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0-beta.3" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0-rc.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ProductionProperties.xml
+++ b/src/ProductionProperties.xml
@@ -3,7 +3,7 @@
 
   <!-- Version information -->
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Changes since 1.0.0-beta04:

- Updated to CloudNative.CloudEvents version 2.0.0-rc.1
- ProtobufJsonCloudEventFormatter signatures updated accordingly to use `ReadOnlyMemory<byte>`