### PR TITLE
Update dependencies in Google.Events.Protobuf

### DIFF
--- a/src/Google.Events.Protobuf/Google.Events.Protobuf.csproj
+++ b/src/Google.Events.Protobuf/Google.Events.Protobuf.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="2.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.8" />
-    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Google.Events.ValidateSchema/Google.Events.ValidateSchema.csproj
+++ b/src/Google.Events.ValidateSchema/Google.Events.ValidateSchema.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <Compile Include="../../tmp/ValidationSource/**" />
   </ItemGroup>
 


### PR DESCRIPTION
(This is primarily to pick up CE SDK 2.1.1.)