### PR TITLE
build: Remove duplicate dependency

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,10 +3,7 @@
     -  error : SourceRoot items must include at least one top-level
     - (not nested) item when DeterministicSourcePaths is true
     -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-  </ItemGroup>
-
+  
   <!-- See https://github.com/dotnet/sourcelink/issues/572 -->
   <PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>


### PR DESCRIPTION
By now, I'm guessing something changed in GitHub action images where these duplicate dependencies are being catched, and they weren't before anywhere else.

This made fail presubmits on #121, that we probably don't want anyway.