### PR TITLE
deps: update protoc to 3.19.0, consistent with generator script.

### DIFF
--- a/validate-schema.sh
+++ b/validate-schema.sh
@@ -35,7 +35,7 @@ cd $(dirname $(readlink -f "$0"))
 rm -rf tmp
 mkdir tmp
 
-PROTOBUF_VERSION=3.12.3
+PROTOBUF_VERSION=3.19.0
 case "$OSTYPE" in
   linux*)
     PROTOBUF_PLATFORM=linux-x86_64


### PR DESCRIPTION
This is needed to support some newly-added `optional` fields in a proto3 file added to the `google-cloudevents` repo.
see https://github.com/googleapis/google-cloudevents/issues/405 for full context.