### PR TITLE
chore: Update packaging to use PackageLicenseExpression

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
     <Authors>Google LLC</Authors>
     <!-- TODO: PackageIcon, PackageIconUrl when we have appropriate ones -->
     <RepositoryType>git</RepositoryType>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/googleapis/google-cloudevents-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/googleapis/google-cloudevents-dotnet</RepositoryUrl>


### PR DESCRIPTION
We still include the license file within the package, so we continue to meet all obligations, but this is easier for customers to validate.

(Non-urgent to review.)