### PR TITLE
ci: Remove missleading renovate ignore path.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     ":disableDependencyDashboard"
   ],
   "ignorePaths": [
-    "src/Google.Events.Protobuf/**",
     ".kokoro/**"
   ],
   "schedule": ["before 8am"],


### PR DESCRIPTION
Because of https://github.com/renovatebot/renovate/discussions/31436, this is now being overriden by the `config:base` presets, and this path will not be ignored.

We may want some dependencies here to be updated anyway, and we can manually close the ones we don't want. Those won't be a lot.