### PR TITLE
fix(ci): Configure release-trigger to be multi SCM

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,1 +1,2 @@
 enabled: true
+multiScmName: google-cloudevents-dotnet


### PR DESCRIPTION
The new CI infrastructure is Kokoro multi scm.
Towards b/393154773