### PR TITLE
chore: Delete leftover configuration from release-trigger

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,2 +1,0 @@
-enabled: true
-multiScmName: google-cloudevents-dotnet


### PR DESCRIPTION
Releases for this repo are already being executed internally. See b/390674325.